### PR TITLE
fix: remove license from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@
 
 ---
 name: 🛠️ Feature Request
-description: Suggest an idea to help us improve W&B
+description: Suggest an idea to help us improve Whiteprint
 title: "feat: "
 labels:
   - "enhancement"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,6 @@
-<!--
-SPDX-FileCopyrightText: © 2023 Romain Brault <mail@romainbrault.com>
+We are happy to accept contributions from our users 🚀.
 
-SPDX-License-Identifier: MIT
--->
-
-We are happy to accept contributions from our users 🚀. For more details on how to contribute see [here](https://github.com/RomainBrault/python-whiteprint/blob/main/CONTRIBUTING.md).
+For more details on how to contribute see [here](https://github.com/RomainBrault/python-whiteprint/blob/main/CONTRIBUTING.md).
 
 # Checklist:
 
@@ -27,5 +23,5 @@ Fixes # (issue)
 Please describe the tests that you ran to verify your changes. Please also note
 any relevant details for your test configuration.
 
-- [ ] Test A
-- [ ] Test B
+- Test A
+- Test B

--- a/.github/PULL_REQUEST_TEMPLATE.md.license
+++ b/.github/PULL_REQUEST_TEMPLATE.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: © 2023 Romain Brault <mail@romainbrault.com>
+
+SPDX-License-Identifier: MIT

--- a/template/{% if git_platform == 'github' %}.github{% endif %}/ISSUE_TEMPLATE/feature_request.yml
+++ b/template/{% if git_platform == 'github' %}.github{% endif %}/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@
 
 ---
 name: 🛠️ Feature Request
-description: Suggest an idea to help us improve W&B
+description: Suggest an idea to help us improve {{project_name}}
 title: "feat: "
 labels:
   - "enhancement"

--- a/template/{% if git_platform == 'github' %}.github{% endif %}/PULL_REQUEST_TEMPLATE.md
+++ b/template/{% if git_platform == 'github' %}.github{% endif %}/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
-{% include "jinja_template/license_header.md.j2" %}
-We are happy to accept contributions from our users 🚀. For more details on how to contribute see [here](https://github.com/{{github_user}}/{{project_slug}}/blob/main/CONTRIBUTING.md).
+We are happy to accept contributions from our users 🚀.
+
+For more details on how to contribute see [here](https://github.com/{{github_user}}/{{project_slug}}/blob/main/CONTRIBUTING.md).
 
 # Checklist:
 
@@ -22,5 +23,5 @@ Fixes # (issue)
 Please describe the tests that you ran to verify your changes. Please also note
 any relevant details for your test configuration.
 
-- [ ] Test A
-- [ ] Test B
+- Test A
+- Test B

--- a/template/{% if git_platform == 'github' %}.github{% endif %}/PULL_REQUEST_TEMPLATE.md.license
+++ b/template/{% if git_platform == 'github' %}.github{% endif %}/PULL_REQUEST_TEMPLATE.md.license
@@ -1,0 +1,1 @@
+{% include "jinja_template/license_header.j2" -%}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Romain Brault <mail@romainbrault.com>

SPDX-License-Identifier: MIT
-->

Remove license from pull request template

# Checklist:

- [x] I agree to follow this project's Code of Conduct
- [x] I have read the [Contributor Guide](https://github.com/RomainBrault/python-whiteprint/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

# Description

remove license header and add it to external file.

Fixes # (issue)

# How Has This Been Tested?

- Run the existing test suite
